### PR TITLE
:sparkles: Bootstrap cobra CLI library

### DIFF
--- a/cmd/dstest/cmd/root.go
+++ b/cmd/dstest/cmd/root.go
@@ -1,0 +1,65 @@
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+	"os"
+)
+
+var DEFAULT_COMMAND = "run"
+
+// rootCmd represents the base command when called without any subcommands
+var rootCmd = &cobra.Command{
+	Use:   "dstest",
+	Short: "Testing distributed systems, one Heisenbug at a time",
+	Long: `dstest is a concurrency testing tool for distributed systems.
+It is designed to test distributed systems with different
+schedulers and network configurations without the need to
+instrument the system under test.`,
+	// Uncomment the following line if your bare application
+	// has an action associated with it:
+	Run: func(cmd *cobra.Command, args []string) {
+		// print hello world
+		cmd.Println("Hello, World!")
+	},
+}
+
+// Execute adds all child commands to the root command and sets flags appropriately.
+// This is called by main.main(). It only needs to happen once to the rootCmd.
+func Execute() {
+	err := rootCmd.Execute()
+	if err != nil {
+		os.Exit(1)
+	}
+}
+
+func init() {
+	// Here you will define your flags and configuration settings.
+	// Cobra supports persistent flags, which, if defined here,
+	// will be global for your application.
+
+	// rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.dstest.yaml)")
+
+	// Cobra also supports local flags, which will only run
+	// when this action is called directly.
+	rootCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
+}
+
+func subCommands() (commandNames []string) {
+	for _, command := range rootCmd.Commands() {
+		commandNames = append(commandNames, append(command.Aliases, command.Name())...)
+	}
+	return
+}
+
+func setDefaultCommandIfNonePresent() {
+	if len(os.Args) > 1 {
+		potentialCommand := os.Args[1]
+		for _, command := range subCommands() {
+			if command == potentialCommand {
+				return
+			}
+		}
+		os.Args = append([]string{os.Args[0], DEFAULT_COMMAND}, os.Args[1:]...)
+	}
+
+}

--- a/cmd/dstest/cmd/run.go
+++ b/cmd/dstest/cmd/run.go
@@ -1,0 +1,48 @@
+package cmd
+
+import (
+	"fmt"
+	"github.com/egeberkaygulcan/dstest/cmd/dstest/config"
+	"github.com/egeberkaygulcan/dstest/cmd/dstest/engine"
+	"github.com/spf13/cobra"
+	"log"
+)
+
+// runCmd represents the run command
+var runCmd = &cobra.Command{
+	Use:   "run",
+	Short: "Run the test engine",
+	Long:  `Run the test engine with the given configuration.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		fmt.Println("run called")
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(runCmd)
+	// Here you will define your flags and configuration settings.
+
+	// Cobra supports Persistent Flags which will work for this command
+	// and all subcommands, e.g.:
+	// runCmd.PersistentFlags().String("foo", "", "A help for foo")
+
+	// Cobra supports local flags which will only run when this command
+	// is called directly, e.g.:
+	// runCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
+
+	fmt.Println("Starting dstest")
+	// Read config
+	cfg, err := config.Read()
+	if err != nil {
+		log.Fatal(err.Error())
+	}
+
+	// -----------------------------
+
+	fmt.Println("Name: " + cfg.TestConfig.Name)
+
+	te := new(engine.TestEngine)
+	te.Init(cfg)
+
+	te.Run()
+}

--- a/cmd/dstest/main.go
+++ b/cmd/dstest/main.go
@@ -1,30 +1,7 @@
 package main
 
-import (
-	"fmt"
-	"log"
-
-	"github.com/egeberkaygulcan/dstest/cmd/dstest/config"
-	"github.com/egeberkaygulcan/dstest/cmd/dstest/engine"
-)
+import "github.com/egeberkaygulcan/dstest/cmd/dstest/cmd"
 
 func main() {
-
-	// ------ DO NOT CHANGE -------
-
-	fmt.Println("Starting dstest")
-	// Read config
-	cfg, err := config.Read()
-	if err != nil {
-		log.Fatal(err.Error())
-	}
-
-	// -----------------------------
-
-	fmt.Println("Name: " + cfg.TestConfig.Name)
-
-	te := new(engine.TestEngine)
-	te.Init(cfg)
-
-	te.Run()
+	cmd.Execute()
 }

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 require (
 	github.com/fsnotify/fsnotify v1.7.0 // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect
+	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/magiconair/properties v1.8.7 // indirect
 	github.com/mitchellh/mapstructure v1.5.0 // indirect
 	github.com/pelletier/go-toml/v2 v2.1.0 // indirect
@@ -18,6 +19,7 @@ require (
 	github.com/sourcegraph/conc v0.3.0 // indirect
 	github.com/spf13/afero v1.11.0 // indirect
 	github.com/spf13/cast v1.6.0 // indirect
+	github.com/spf13/cobra v1.8.1 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/subosito/gotenv v1.6.0 // indirect
 	go.uber.org/atomic v1.9.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,4 @@
+github.com/cpuguy83/go-md2man/v2 v2.0.4/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
@@ -7,6 +8,8 @@ github.com/fsnotify/fsnotify v1.7.0/go.mod h1:40Bi/Hjc2AVfZrqy+aj+yEI+/bRxZnMJyT
 github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
 github.com/hashicorp/hcl v1.0.0 h1:0Anlzjpi4vEasTeNFn2mLJgTSwt0+6sfsiTG8qcWGx4=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
+github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
+github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
 github.com/magiconair/properties v1.8.7 h1:IeQXZAiQcpL9mgcAe1Nu6cX9LLw6ExEHKjN0VQdvPDY=
@@ -18,6 +21,7 @@ github.com/pelletier/go-toml/v2 v2.1.0/go.mod h1:tJU2Z3ZkXwnxa4DPO899bsyIoywizdU
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRIccs7FGNTlIRMkT8wgtp5eCXdBlqhYGL6U=
 github.com/rogpeppe/go-internal v1.9.0 h1:73kH8U+JUqXU8lRuOHeVHaa/SZPifC7BkcraZVejAe8=
+github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/sagikazarmark/locafero v0.4.0 h1:HApY1R9zGo4DBgr7dqsTH/JJxLTTsOt7u6keLGt6kNQ=
 github.com/sagikazarmark/locafero v0.4.0/go.mod h1:Pe1W6UlPYUk/+wc/6KFhbORCfqzgYEpgQ3O5fPuL3H4=
 github.com/sagikazarmark/slog-shim v0.1.0 h1:diDBnUNK9N/354PgrxMywXnAwEr1QZcOr6gto+ugjYE=
@@ -28,6 +32,8 @@ github.com/spf13/afero v1.11.0 h1:WJQKhtpdm3v2IzqG8VMqrr6Rf3UYpEF239Jy9wNepM8=
 github.com/spf13/afero v1.11.0/go.mod h1:GH9Y3pIexgf1MTIWtNGyogA5MwRIDXGUr+hbWNoBjkY=
 github.com/spf13/cast v1.6.0 h1:GEiTHELF+vaR5dhz3VqZfFSzZjYbgeKDpBxQVS4GYJ0=
 github.com/spf13/cast v1.6.0/go.mod h1:ancEpBxwJDODSW/UG4rDrAqiKolqNNh2DX3mk86cAdo=
+github.com/spf13/cobra v1.8.1 h1:e5/vxKd/rZsfSJMUX1agtjeTDf+qv1/JdBF8gg5k9ZM=
+github.com/spf13/cobra v1.8.1/go.mod h1:wHxEcudfqmLYa8iTfL+OuZPbBZkmvliBWKIezN3kD9Y=
 github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
 github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/spf13/viper v1.18.2 h1:LUXCnvUvSM6FXAsj6nnfc8Q2tp1dIgUfY9Kc8GsSOiQ=


### PR DESCRIPTION
This adds the [Cobra](https://github.com/spf13/cobra) CLI library to the project.

From the _Internets_, it looks like Cobra and Viper get along together to solve the problems of having a usable CLI and loading configuration respectively.

I'll YOLO merge this one, though! 🤞🏻