### PR TITLE
:sparkles: link cobra to viper

### DIFF
--- a/cmd/dstest/cmd/root.go
+++ b/cmd/dstest/cmd/root.go
@@ -17,10 +17,7 @@ schedulers and network configurations without the need to
 instrument the system under test.`,
 	// Uncomment the following line if your bare application
 	// has an action associated with it:
-	Run: func(cmd *cobra.Command, args []string) {
-		// print hello world
-		cmd.Println("Hello, World!")
-	},
+	//Run: func(cmd *cobra.Command, args []string) {},
 }
 
 // Execute adds all child commands to the root command and sets flags appropriately.
@@ -41,9 +38,12 @@ func init() {
 
 	// Cobra also supports local flags, which will only run
 	// when this action is called directly.
-	rootCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
+	//rootCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
 }
 
+/*
+// we can set a default command to run by default if no command is provided
+// stolen from https://github.com/spf13/cobra/issues/823#issuecomment-617863653
 func subCommands() (commandNames []string) {
 	for _, command := range rootCmd.Commands() {
 		commandNames = append(commandNames, append(command.Aliases, command.Name())...)
@@ -63,3 +63,4 @@ func setDefaultCommandIfNonePresent() {
 	}
 
 }
+*/

--- a/cmd/dstest/cmd/run.go
+++ b/cmd/dstest/cmd/run.go
@@ -5,6 +5,7 @@ import (
 	"github.com/egeberkaygulcan/dstest/cmd/dstest/config"
 	"github.com/egeberkaygulcan/dstest/cmd/dstest/engine"
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 	"log"
 )
 
@@ -14,7 +15,25 @@ var runCmd = &cobra.Command{
 	Short: "Run the test engine",
 	Long:  `Run the test engine with the given configuration.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Println("run called")
+		for key, value := range viper.GetViper().AllSettings() {
+			fmt.Printf("%s: %s\n", key, value)
+		}
+		fmt.Println("Starting dstest")
+
+		// Read config
+		cfg, err := config.Read()
+		if err != nil {
+			log.Fatal(err.Error())
+		}
+
+		// -----------------------------
+
+		fmt.Println("Name: " + cfg.TestConfig.Name)
+
+		te := new(engine.TestEngine)
+		te.Init(cfg)
+
+		te.Run()
 	},
 }
 
@@ -30,19 +49,14 @@ func init() {
 	// is called directly, e.g.:
 	// runCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
 
-	fmt.Println("Starting dstest")
-	// Read config
-	cfg, err := config.Read()
+	// path to configuration file
+	runCmd.PersistentFlags().StringP("config", "c", "./config/config.yml", "Path to configuration file")
+	err := viper.BindPFlag("config", runCmd.PersistentFlags().Lookup("config"))
 	if err != nil {
-		log.Fatal(err.Error())
+		log.Fatal(fmt.Errorf("error binding flag: %v", err))
+		return
 	}
 
-	// -----------------------------
-
-	fmt.Println("Name: " + cfg.TestConfig.Name)
-
-	te := new(engine.TestEngine)
-	te.Init(cfg)
-
-	te.Run()
+	//runCmd.PersistentFlags().StringP("name", "n", "default", "Name of the test")
+	//err = viper.BindPFlag("name", runCmd.PersistentFlags().Lookup("name"))
 }

--- a/cmd/dstest/config/config.go
+++ b/cmd/dstest/config/config.go
@@ -1,7 +1,6 @@
 package config
 
 import (
-	"bytes"
 	_ "embed"
 	"os"
 	"path/filepath"
@@ -9,9 +8,6 @@ import (
 
 	"github.com/spf13/viper"
 )
-
-//go:embed config.yml
-var defaultConfiguration []byte
 
 type TestConfig struct {
 	Name        string
@@ -63,14 +59,15 @@ func ModifyFilepath(config *Config) {
 func Read() (*Config, error) {
 	// Environment variables
 	viper.AutomaticEnv()
-	viper.SetEnvPrefix("APP")
+	//viper.SetEnvPrefix("APP")
 	viper.SetEnvKeyReplacer(strings.NewReplacer(".", "_", "-", "_"))
 
 	// Configuration file type
+	viper.SetConfigFile(viper.GetString("config"))
 	viper.SetConfigType("yml")
 
 	// Read configuration
-	if err := viper.ReadConfig(bytes.NewBuffer(defaultConfiguration)); err != nil {
+	if err := viper.ReadInConfig(); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
This links cobra (CLI) with viper (config).

We can set the path to the configuration file via `--config` or `-c`.

Default is `./config/config.yml`, which loads the same file as before.