### PR TITLE
About pct scheduler

### DIFF
--- a/cmd/dstest/network/manager.go
+++ b/cmd/dstest/network/manager.go
@@ -178,7 +178,7 @@ func (nm *Manager) SendMessage(messageId uint64) {
 			if mq.Peek().MessageId == messageId {
 				message := mq.PopFront()
 				message.SendMessage()
-				// nm.updateVectorClocks(message.Sender, message.Receiver)
+				nm.updateVectorClocks(message.Sender, message.Receiver)
 			}
 		}
 	}

--- a/cmd/dstest/network/manager.go
+++ b/cmd/dstest/network/manager.go
@@ -34,7 +34,7 @@ type Manager struct {
 	ReplicaIds    []int
 	PortMap       map[int]SenderReceiverPair
 	MessageType   MessageType
-	// VectorClocks map[int]map[int]int
+	VectorClocks map[int]map[int]int
 	ChainClocks [][]Event
 }
 
@@ -48,7 +48,7 @@ func (nm *Manager) Init(config *config.Config, replicaIds []int) error {
 	nm.Interceptors = make([]Interceptor, numReplicas * (numReplicas - 1))
 	nm.MessageQueues = make([]*MessageQueue, numReplicas)
 	nm.ReplicaIds = replicaIds
-	// nm.VectorClocks = make(map[int]map[int]int)
+	nm.VectorClocks = make(map[int]map[int]int)
 	nm.ChainClocks = make([][]Event, 0)
 	nm.Index.Store(0)
 
@@ -126,19 +126,39 @@ func max(x, y int) int {
 	return y
 }
 
-// func (nm *Manager) updateVectorClocks(sender, receiver int) {
-// 	// Update sender clock
-// 	nm.VectorClocks[sender][sender]++
+func (nm *Manager) updateVectorClocks(sender, receiver int) {
 
-// 	// Update receiver clock
-// 	for _, id := range nm.ReplicaIds {
-// 		if id != receiver {
-// 			nm.VectorClocks[receiver][id] = max(nm.VectorClocks[receiver][id], nm.VectorClocks[sender][id])
-// 		} else {
-// 			nm.VectorClocks[receiver][receiver]++
-// 		}
-// 	}
-// }
+	 //initialize inner maps 
+	if nm.VectorClocks[sender] == nil {
+		nm.VectorClocks[sender] = make(map[int]int)
+	}
+	
+	if nm.VectorClocks[receiver] == nil {
+		nm.VectorClocks[receiver] = make(map[int]int)
+	}
+
+	// initialize the entries 
+	if _, exists := nm.VectorClocks[sender][sender]; !exists {
+		nm.VectorClocks[sender][sender] = 0
+	}
+
+	if _, exists := nm.VectorClocks[receiver][receiver]; !exists {
+		nm.VectorClocks[receiver][receiver] = 0
+	}
+
+	 
+ 	// Update sender clock
+ 	nm.VectorClocks[sender][sender]++
+
+ 	// Update receiver clock
+ 	for _, id := range nm.ReplicaIds {
+ 		if id != receiver {
+ 			nm.VectorClocks[receiver][id] = max(nm.VectorClocks[receiver][id], nm.VectorClocks[sender][id])
+ 		} else {
+ 			nm.VectorClocks[receiver][receiver]++
+ 		}
+ 	}
+ }
 
 func (nm *Manager) UpdateChainClocks(sender, receiver int, messageId uint64, name string) {
 	for i, chain := range nm.ChainClocks {

--- a/cmd/dstest/network/manager.go
+++ b/cmd/dstest/network/manager.go
@@ -34,7 +34,7 @@ type Manager struct {
 	ReplicaIds    []int
 	PortMap       map[int]SenderReceiverPair
 	MessageType   MessageType
-	VectorClocks map[int]map[int]int
+	// VectorClocks map[int]map[int]int
 	ChainClocks [][]Event
 }
 
@@ -48,7 +48,7 @@ func (nm *Manager) Init(config *config.Config, replicaIds []int) error {
 	nm.Interceptors = make([]Interceptor, numReplicas * (numReplicas - 1))
 	nm.MessageQueues = make([]*MessageQueue, numReplicas)
 	nm.ReplicaIds = replicaIds
-	nm.VectorClocks = make(map[int]map[int]int)
+	// nm.VectorClocks = make(map[int]map[int]int)
 	nm.ChainClocks = make([][]Event, 0)
 	nm.Index.Store(0)
 
@@ -74,14 +74,6 @@ func (nm *Manager) Init(config *config.Config, replicaIds []int) error {
 				k++
 			}
 		}
-
-		// initialize vector clocks		
-		nm.VectorClocks[i] = make(map[int]int)
-		
-		for j :=0; j<numReplicas; j++ {		
-			nm.VectorClocks[i][j] = 0
-		}
-
 	}
 
 	// FIXME: This is a temporary solution to avoid nil pointer dereference
@@ -134,20 +126,19 @@ func max(x, y int) int {
 	return y
 }
 
-func (nm *Manager) updateVectorClocks(sender, receiver int) {
-	 
- 	// Update sender clock
- 	nm.VectorClocks[sender][sender]++
+// func (nm *Manager) updateVectorClocks(sender, receiver int) {
+// 	// Update sender clock
+// 	nm.VectorClocks[sender][sender]++
 
- 	// Update receiver clock
- 	for _, id := range nm.ReplicaIds {
- 		if id != receiver {
- 			nm.VectorClocks[receiver][id] = max(nm.VectorClocks[receiver][id], nm.VectorClocks[sender][id])
- 		} else {
- 			nm.VectorClocks[receiver][receiver]++
- 		}
- 	}
- }
+// 	// Update receiver clock
+// 	for _, id := range nm.ReplicaIds {
+// 		if id != receiver {
+// 			nm.VectorClocks[receiver][id] = max(nm.VectorClocks[receiver][id], nm.VectorClocks[sender][id])
+// 		} else {
+// 			nm.VectorClocks[receiver][receiver]++
+// 		}
+// 	}
+// }
 
 func (nm *Manager) UpdateChainClocks(sender, receiver int, messageId uint64, name string) {
 	for i, chain := range nm.ChainClocks {
@@ -167,7 +158,7 @@ func (nm *Manager) SendMessage(messageId uint64) {
 			if mq.Peek().MessageId == messageId {
 				message := mq.PopFront()
 				message.SendMessage()
-				nm.updateVectorClocks(message.Sender, message.Receiver)
+				// nm.updateVectorClocks(message.Sender, message.Receiver)
 			}
 		}
 	}

--- a/cmd/dstest/network/manager.go
+++ b/cmd/dstest/network/manager.go
@@ -74,6 +74,14 @@ func (nm *Manager) Init(config *config.Config, replicaIds []int) error {
 				k++
 			}
 		}
+
+		// initialize vector clocks		
+		nm.VectorClocks[i] = make(map[int]int)
+		
+		for j :=0; j<numReplicas; j++ {		
+			nm.VectorClocks[i][j] = 0
+		}
+
 	}
 
 	// FIXME: This is a temporary solution to avoid nil pointer dereference
@@ -127,25 +135,6 @@ func max(x, y int) int {
 }
 
 func (nm *Manager) updateVectorClocks(sender, receiver int) {
-
-	 //initialize inner maps 
-	if nm.VectorClocks[sender] == nil {
-		nm.VectorClocks[sender] = make(map[int]int)
-	}
-	
-	if nm.VectorClocks[receiver] == nil {
-		nm.VectorClocks[receiver] = make(map[int]int)
-	}
-
-	// initialize the entries 
-	if _, exists := nm.VectorClocks[sender][sender]; !exists {
-		nm.VectorClocks[sender][sender] = 0
-	}
-
-	if _, exists := nm.VectorClocks[receiver][receiver]; !exists {
-		nm.VectorClocks[receiver][receiver] = 0
-	}
-
 	 
  	// Update sender clock
  	nm.VectorClocks[sender][sender]++

--- a/cmd/dstest/scheduling/PCT.go
+++ b/cmd/dstest/scheduling/PCT.go
@@ -40,7 +40,7 @@ func (s *PCT) Init(config *config.Config) {
 	s.Step = 0
 	s.PriorityChangePoints = make([]int, 0)
 	s.InitialPriorities = make([]int, 0)
-	for i := 1; i < s.Depth; i++ { //depth-1 priority change points? 
+	for i := 1; i < s.Depth; i++ { 
 		s.PriorityChangePoints = append(s.PriorityChangePoints, s.distinctRandomInteger(s.Config.SchedulerConfig.Steps, s.PriorityChangePoints))
 	}
 	//PriorityChangePoints is iterated and compared to the current step number (increasing sequence) - so the list should be sorted.
@@ -80,7 +80,7 @@ func (s *PCT) NextIteration() {
 	s.Step = 0
 	s.PriorityChangePoints = make([]int, 0)
 	s.InitialPriorities = make([]int, 0)
-	for i := 1; i < s.Depth; i++ { //depth-1 priority change points? 
+	for i := 1; i < s.Depth; i++ { 
 		s.PriorityChangePoints = append(s.PriorityChangePoints, s.distinctRandomInteger(s.Config.SchedulerConfig.Steps, s.PriorityChangePoints))
 	}
 	sort.Ints(s.PriorityChangePoints)
@@ -100,12 +100,10 @@ func (s *PCT) Shutdown() {
 
 // Returns a random index from available messages
 func (s *PCT) Next(messages []*network.Message, faults []*faults.Fault, context faults.FaultContext) SchedulerDecision {
-	if s.NumPriorityChanged < (s.Depth-1) { // indexes start with 0.
+	if s.NumPriorityChanged < (s.Depth-1) { 
 		if s.Step == s.PriorityChangePoints[s.NumPriorityChanged] {
 			s.NumPriorityChanged++
-			s.NumPriorityChange  =  (s.NumPriorityChange +1 )  % ( s.Config.ProcessConfig.NumReplicas -1 )//treats InitialPriorities as a circular list. 
-			// NumpriorityChange isOF {0,1,2}
-			// NumpriorityChanged isOF {0,1,... depth-2}
+			s.NumPriorityChange  =  (s.NumPriorityChange +1 )  % ( s.Config.ProcessConfig.NumReplicas -1 )
 		}
 	}
 

--- a/cmd/dstest/scheduling/PCT.go
+++ b/cmd/dstest/scheduling/PCT.go
@@ -119,7 +119,7 @@ func (s *PCT) Next(messages []*network.Message, faults []*faults.Fault, context 
 		}
 
 		if decision < 0 {
-			s.Step = s.Step - 1 //if step is not decremented, the step number does not match with the step number the test engine counts.
+			//s.Step = s.Step - 1 //if step is not decremented, the step number does not match with the step number the test engine counts.
 			return SchedulerDecision{
 				DecisionType: NoOp,
 			}


### PR DESCRIPTION
Hi, 

Because of #34 , I wanted to see what might be the problem and if it's an easy fix. Maybe this is not the correct solution yet, but it resolves the issue and it may be helpful to share it, so I am creating this pull request.

For this version, I used 2 different variables to (1) iterate through the priority change points list and 
(2) iterate through the initial priorities list. The initial priorities list is treated as a circular list. 

Also the final length of the priority change points list was same as the depth parameter but I made it be depth -1. 

**Note:** I also added it as a comment but I would like to open this as a discussion. When NoOp is scheduled even though the messages list is not empty, should it decrement the step number (that was incremented as Next is called) to match with the test engine's step number? Or if the aim is to schedule the message with the next highest priority (based on the sender) - and not wait until the sender with the current highest priority queues a message - , shouldn't that be handled before returning NoOp? 
